### PR TITLE
Remove: .jarファイル削除と.gitignore更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ Thumbs.db
 *.log
 *.bak
 .vscode/
-.jar
+*.jar


### PR DESCRIPTION
mainブランチに含まれていた lib/sqlite-jdbc-3.50.1.0.jar を削除し、
.gitignore に *.jar を追加して不要な jar ファイルが含まれないようにしました。